### PR TITLE
Fix for API failure due to wrong shipping tax calculation

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -271,6 +271,8 @@ class Api
      */
     public function createPayment($webProfile, $quote, $taxFailure = false)
     {
+        $quote->setTotalsCollectedFlag(false)->collectTotals()->save();
+        
         $payer = $this->buildPayer($quote);
 
         $itemList = $this->buildItemList($quote, $taxFailure);
@@ -317,6 +319,8 @@ class Api
      */
     public function patchPayment($quote)
     {
+        $quote->setTotalsCollectedFlag(false)->collectTotals()->save();
+        
         if ($this->customerSession->getPayPalPaymentId()) {
             $payment = PayPalPayment::get($this->customerSession->getPayPalPaymentId(), $this->_apiContext);
             $patchRequest = new PatchRequest();


### PR DESCRIPTION
The paypal plus module fails sometimes with the following error:
PayPal\Core\PayPalHttpConnection : ERROR: Got Http response code 400 when accessing https://api.paypal.com/v1/payments/payment. {"name":"VALIDATION_ERROR","details":[{"field":"transactions[0].amount","issue":"Transaction amount details (subtotal, tax, shipping) must add up to specified amount total"}],"message":"Invalid request - see details","information_link":"https://developer.paypal.com/docs/api/payments/#errors","debug_id":"xxxxxxxxx"}

The reason is a bug in Magento2. If the shop uses shipping rates inclusive Tax the result of getBaseShippingAmount sometimes returns the shipping rate including tax unless the card will be recalculated.

$quote->setTotalsCollectedFlag(false)->collectTotals()->save() takes care that the shipping amount is allways without tax.