### PR TITLE
Patch also item list (e.g. qty update) 

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -344,6 +344,13 @@ class Api
             $payerInfoPatch->setValue($payerInfo);
             $patchRequest->addPatch($payerInfoPatch);
 
+            $itemList = $this->buildItemList($quote, false);
+            $itemListPatch = new Patch();
+            $itemListPatch->setOp('replace');
+            $itemListPatch->setPath('/transactions/0/item_list');
+            $itemListPatch->setValue($itemList);
+            $patchRequest->addPatch($itemListPatch);
+
             $amount = $this->buildAmount($quote);
             $amountPatch = new Patch();
             $amountPatch->setOp('replace');


### PR DESCRIPTION
Patch payment should also patch the item list.

We use a One-Step-Checkout and if the customer updates the qty of one or more items, paypal response at patch-request the following error:

~~~
{"name":"VALIDATION_ERROR","details":[{"field":"purchase_units[0]","issue":"Item amount must add up to specified amount subtotal (or total if amount details not specified)"}],"message":"Invalid request - see details","information_link":"https://developer.paypal.com/docs/api/payments/#errors","debug_id":"fca9b3707a952"}
~~~