### PR TITLE
Fixed wording and typo on backend third party modules configuration

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -93,7 +93,7 @@
                         <config_path>payment/iways_paypalplus_payment/specificcountry</config_path>
                     </field>
                     <field id="third_party_moduls" translate="label" type="multiselect" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
-                        <label>Allowed Third-Party Moduls</label>
+                        <label>Disallowed Third-Party Modules</label>
                         <source_model>Iways\PayPalPlus\Model\System\Config\Source\ThirdPartyModuls</source_model>
                         <can_be_empty>1</can_be_empty>
                         <config_path>payment/iways_paypalplus_payment/third_party_moduls</config_path>

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -9,7 +9,7 @@
 "Enabled","Aktiviert"
 "Payment from Applicable Countries","Ländereinstellung"
 "Payment from Specific Countries","Erlaubte Länder"
-"Allowed Third-Party Moduls","Erlaubte Zahlungsmethoden von Drittanbietern"
+"Disallowed Third-Party Modules","Erlaubte Zahlungsmethoden von Drittanbietern"
 "Only select payment methods which doesn't require extra input in checkout.","Bitte wählen Sie nur Zahlungsmethoden aus, die keine weiteren Eingaben im Checkout benötigen."
 "PayPalPlus Development Settings","PayPalPlus Entwicklereinstellungen"
 "Enable autoloader for PayPal SDK","PayPalSDK-Autoloader aktiv"


### PR DESCRIPTION
After selecting payment methods under "PayPalPlus Payment Settings", all selected methods are missing from the checkout, while the not selected ones are available.
I fixed this by changing "Allowed" to "Disallowed".
Now payment methods marked as disallowed won't be in the checkout.

As you can see, I marked no payment methods as allowed:
![bildschirmfoto 2018-10-30 um 15 15 16](https://user-images.githubusercontent.com/12683535/47727053-04c63280-dc5c-11e8-94a3-80a139377c19.png)

But still, all enabled methods are available in the checkout:
![bildschirmfoto 2018-10-30 um 15 14 53](https://user-images.githubusercontent.com/12683535/47727052-04c63280-dc5c-11e8-9356-ca12bdcbbdd5.png)




Also "modules" was spelled wrong.