### PR TITLE
Show third party method if allowed

### DIFF
--- a/Model/MethodList.php
+++ b/Model/MethodList.php
@@ -81,7 +81,7 @@ class MethodList extends \Magento\Payment\Model\MethodList
                     if (
                     ($method->getCode() == Payment::CODE
                         || $method->getCode() == self::AMAZON_PAYMENT
-                        || !in_array($method->getCode(), $allowedPPPMethods))
+                        || in_array($method->getCode(), $allowedPPPMethods))
                     ) {
                         $methods[] = $method;
                     }


### PR DESCRIPTION
Currently we add all payment methods to the `$methods` array if it is NOT selected in the backend. This PR fixes this behaviour.