### PR TITLE
Fix Prevent duplicate confirmation emails to customers

### DIFF
--- a/Controller/Order/Create.php
+++ b/Controller/Order/Create.php
@@ -123,7 +123,9 @@ class Create extends \Magento\Framework\App\Action\Action
                 $order = $this->orderFactory->create()->load($orderId);
                 if ($order->getCanSendNewEmailFlag()) {
                     try {
-                        $this->orderSender->send($order);
+						if (!$order->getEmailSent()) {
+							$this->orderSender->send($order);
+						}
                     } catch (\Exception $e) {
                         $this->logger->critical($e);
                     }


### PR DESCRIPTION
If the asynchronous sending of emails is disabled,  in most cases Magento 2.3 will send two confirmation emails to the customer. The additional query of getEmailSent should prevent this.
The error does not occur with asynchronous mail sending. However, due to the catastrophic implementation  of the new inventory in Magento 2.3, this is no longer an option.