### PR TITLE
Add possibility to set images to third party methods

### DIFF
--- a/Block/Adminhtml/System/Config/ThirdPartyInfo.php
+++ b/Block/Adminhtml/System/Config/ThirdPartyInfo.php
@@ -55,19 +55,24 @@ class ThirdPartyInfo extends \Magento\Config\Block\System\Config\Form\Fieldset
         foreach ($this->paymentConfig->getActiveMethods() as $paymentMethod) {
             if (in_array($paymentMethod->getCode(), $thirdPartyMethods)) {
                 $thirdPartyMethod = $paymentMethod->getCode();
-                $field = clone $dummyField;
-                $field->setData('name', str_replace('dummy', $thirdPartyMethod, $field->getName()));
-                $field->setData('label', $paymentMethod->getTitle());
-                $field->setData('value', $this->_scopeConfig->getValue('payment/iways_paypalplus_section/third_party_modul_info/text_' . $thirdPartyMethod));
-                $fieldConfig = $field->getData('field_config');
-                $fieldConfig['id'] = 'text_' . $thirdPartyMethod;
-                $fieldConfig['label'] = $paymentMethod->getTitle();
-                $fieldConfig['config_path'] =
-                    'payment/iways_paypalplus_section/third_party_modul_info/text_' . $thirdPartyMethod;
 
-                $field->setData('field_config', $fieldConfig);
-                $field->setData('html_id', str_replace('dummy', $thirdPartyMethod, $field->getData('html_id')));
-                $html .= $field->toHtml();
+                foreach(['text', 'image'] as $item){
+
+                    $field = clone $dummyField;
+                    $field->setData('name', str_replace('item_dummy', $item.'_'.$thirdPartyMethod, $field->getName()));
+                    $field->setData('label', $paymentMethod->getTitle());
+                    $field->setData('value', $this->_scopeConfig->getValue('payment/iways_paypalplus_section/third_party_modul_info/'.$item.'_' . $thirdPartyMethod));
+                    $fieldConfig = $field->getData('field_config');
+                    $fieldConfig['id'] = $item.'_' . $thirdPartyMethod;
+                    $fieldConfig['label'] = $paymentMethod->getTitle();
+                    $fieldConfig['config_path'] =
+                        'payment/iways_paypalplus_section/third_party_modul_info/'.$item.'_' . $thirdPartyMethod;
+
+                    $field->setData('field_config', $fieldConfig);
+                    $field->setData('html_id', str_replace('item_dummy', $item.'_'.$thirdPartyMethod, $field->getData('html_id')));
+                    $html .= $field->toHtml();
+                }
+
             }
         }
         $html .= $this->_getFooterHtml($element);

--- a/Block/Adminhtml/System/Config/ThirdPartyInfo.php
+++ b/Block/Adminhtml/System/Config/ThirdPartyInfo.php
@@ -60,7 +60,7 @@ class ThirdPartyInfo extends \Magento\Config\Block\System\Config\Form\Fieldset
 
                     $field = clone $dummyField;
                     $field->setData('name', str_replace('item_dummy', $item.'_'.$thirdPartyMethod, $field->getName()));
-                    $field->setData('label', $paymentMethod->getTitle());
+                    $field->setData('label', $paymentMethod->getTitle() . ' ' . __($item));
                     $field->setData('value', $this->_scopeConfig->getValue('payment/iways_paypalplus_section/third_party_modul_info/'.$item.'_' . $thirdPartyMethod));
                     $fieldConfig = $field->getData('field_config');
                     $fieldConfig['id'] = $item.'_' . $thirdPartyMethod;

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -100,7 +100,7 @@
                     </field>
                 </group>
                 <group id="third_party_modul_info" type="text" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="30">
-                    <label>PayPalPlus Third party methods info text</label>
+                    <label>PayPalPlus Third party methods info</label>
                     <comment>Only selected and saved third party payments will be shown.</comment>
                     <frontend_model>Iways\PayPalPlus\Block\Adminhtml\System\Config\ThirdPartyInfo</frontend_model>
                     <field id="item_dummy" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -103,9 +103,9 @@
                     <label>PayPalPlus Third party methods info text</label>
                     <comment>Only selected and saved third party payments will be shown.</comment>
                     <frontend_model>Iways\PayPalPlus\Block\Adminhtml\System\Config\ThirdPartyInfo</frontend_model>
-                    <field id="text_dummy" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <field id="item_dummy" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>dummy</label>
-                        <config_path>payment/third_party_modul_info/text_dummy</config_path>
+                        <config_path>payment/third_party_modul_info/item_dummy</config_path>
                     </field>
                 </group>
                 <group id="iways_paypalplus_dev" translate="label" showInDefault="1" showInWebsite="1" sortOrder="60">

--- a/i18n/de_DE.csv
+++ b/i18n/de_DE.csv
@@ -1,6 +1,6 @@
 "PayPalPlus Settings","PayPalPlus-Einstellungen"
 "PayPalPlus Payment Settings","PayPalPlus-Einstellungen"
-"PayPalPlus Third party methods info text","PayPalPlus Drittanbieterinformationstexte"
+"PayPalPlus Third party methods info","PayPalPlus Drittanbieterinformationen"
 "Only selected and saved third party payments will be shown.","Nur ausgewählte und gespeicherte Zahlungsmethoden von Drittanbietern werden angezeigt."
 "PayPalPlus Api Settings","PayPalPlus API-Einstellungen"
 "Client ID","Klienten-ID"
@@ -47,3 +47,5 @@
 "Reduces API calls","Reduziert die API-Aufrufe"
 "Only available for merchants located in Germany. Please switch your merchant country to Germany. (Merchant Location -> Merchant Country -> Germany)","Nur verfügbar für Händler mit Standort in Deutschland. Bitte stellen Sie den Händlerstandort auf Deutschland. Händlerstandort -> Händlerland -> Deutschland"
 "Add payment methods to PayPal-Plus frame","Zahlungsmethoden dem PayPal-Plus Frame hinzufügen"
+"text", "Text"
+"image", "Bild"


### PR DESCRIPTION
This PR will add fields for images of third party payment methods on the ppp third party methods info tab.

![image](https://user-images.githubusercontent.com/8124315/53084474-357af200-3501-11e9-84c4-fafbca14a9b4.png)

Users will be able to provide an absolute url or simply enter a relative path that will be resolved to a file within the pub folder. This way images can be versioned in custom themes/modules etc.  

The end result will obviously be custom images for third party payment methods within the ppp payment wall.

![image](https://user-images.githubusercontent.com/8124315/53085146-8dfebf00-3502-11e9-9ba7-107dd8ec913a.png)