### PR TITLE
Fix checkout layout

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -13,7 +13,7 @@
  * License http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>


### PR DESCRIPTION
The standard `checkout_index_index.xml` file of Magento 2 defines the layout as `checkout`. By this, certain elements are hidden from the checkout page. This module currently changes the layout from `checkout` to `1column`. This changes the layout of the checkout after installing the module, which is probably not wanted. This PR fixes this issue.