### PR TITLE
Fixed the online refund (Credit Memo)

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -28,6 +28,7 @@ use PayPal\Api\Address;
 use PayPal\Api\WebProfile;
 use PayPal\Api\Presentation;
 use PayPal\Api\Payment as PayPalPayment;
+use PayPal\Api\Sale as PayPalSale;
 use PayPal\Api\Amount;
 use PayPal\Api\Details;
 use PayPal\Api\InputFields;
@@ -314,6 +315,18 @@ class Api
     }
 
     /**
+     * Get a sale
+     *
+     * @param string $paymentId
+     *
+     * @return \PayPal\Api\Sale
+     */
+    public function getSale($paymentId)
+    {
+        return PayPalSale::get($paymentId, $this->_apiContext);
+    }
+
+    /**
      * Create payment for current quote
      *
      * @param WebProfile $webProfile
@@ -508,9 +521,7 @@ class Api
      */
     public function refundPayment($paymentId, $amount)
     {
-        $transactions = $this->getPayment($paymentId)->getTransactions();
-        $relatedResources = $transactions[0]->getRelatedResources();
-        $sale = $relatedResources[0]->getSale();
+        $sale = $this->getSale($paymentId);
         $refund = new \PayPal\Api\Refund();
 
         $ppAmount = new Amount();


### PR DESCRIPTION
In the current version, the module tries to get a payment used the sale id, not payment id. We don't have a payment id in the database.
We can't use a sale id (example: 7XT39271S22609148) to get payment /v1/payments/payment/<paymentId> (A payment id looks like PAYID-L4NXQMY0VU89255BT411791X).
When we want to refund we get a sale in any case via a payment, I just skip this step and get sale directly via /v1/payments/sale/$saleId
