### PR TITLE
Update name in composer.json to match Marketplace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "iways/module-pay-pal-plus",
+    "name": "iwaysgmbh/module-pay-pal-plus",
     "description": "PayPal PLUS for Magento 2",
     "repositories": [
         {


### PR DESCRIPTION
The extension is currently not listed in the Magento Marketplace due missing support for Magento 2.3 and 2.4: <https://marketplace.magento.com/iwaysgmbh-module-pay-pal-plus.html>
The [documentation|https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/composer-integration.html#vendor-name] requires the _vendor-name_ in `composer.json` to be identical to the _Vendor Name_ in the Magento Marketplace. The former currently is `iways`, the latter is `iwaysgmbh`. This PR harmonizes on `iwaysgmbh`.