### PR TITLE
Fixes call to undefined method 'queueNewOrderEmail' on PayPal webhook callback

### DIFF
--- a/Model/Webhook/Event.php
+++ b/Model/Webhook/Event.php
@@ -181,6 +181,7 @@ class Event
             }
 
             $this->_order->addStatusToHistory(
+                false,
                 __(
                     'Notified customer about invoice #%1.',
                     $invoice->getIncrementId()

--- a/Model/Webhook/Event.php
+++ b/Model/Webhook/Event.php
@@ -18,6 +18,8 @@
 
 namespace Iways\PayPalPlus\Model\Webhook;
 
+use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
+
 /**
  * Iways PayPalPlus Event Handler
  *
@@ -68,6 +70,13 @@ class Event
     protected $salesOrderFactory;
 
     /**
+     * Protected $invoiceSender
+     * 
+     * @var \Magento\Sales\Model\Order\Email\Sender\InvoiceSender
+     */
+    protected $invoiceSender;
+
+    /**
      * Protected $logger
      *
      * @var \Psr\Log\LoggerInterface
@@ -77,10 +86,12 @@ class Event
     public function __construct(
         \Magento\Sales\Model\Order\Payment\TransactionFactory $salesOrderPaymentTransactionFactory,
         \Magento\Sales\Model\OrderFactory $salesOrderFactory,
+        \Magento\Sales\Model\Order\Email\Sender\InvoiceSender $invoiceSender,
         \Psr\Log\LoggerInterface $logger
     ) {
         $this->salesOrderPaymentTransactionFactory = $salesOrderPaymentTransactionFactory;
         $this->salesOrderFactory = $salesOrderFactory;
+        $this->invoiceSender = $invoiceSender;
         $this->logger = $logger;
     }
 
@@ -163,13 +174,19 @@ class Event
         // notify customer
         $invoice = $payment->getCreatedInvoice();
         if ($invoice && !$this->_order->getEmailSent()) {
-            $this->_order->queueNewOrderEmail()
-                ->addStatusHistoryComment(
-                    __(
-                        'Notified customer about invoice #%1.',
-                        $invoice->getIncrementId()
-                    )
-                )->setIsCustomerNotified(true)->save();
+            try {
+                $this->invoiceSender->send($invoice);
+            } catch (\Exception $e) {
+                $this->logger->error($e->getMessage());
+            }
+
+            $this->_order->addStatusToHistory(
+                __(
+                    'Notified customer about invoice #%1.',
+                    $invoice->getIncrementId()
+                ),
+                true
+            )->save();
         }
     }
 


### PR DESCRIPTION
When the webhook call is triggered by PayPal it fails with a 503 and exception.log will show something like this (for whatever reason the errors are German on my system):

```
2022-01-24 16:18:46] main.CRITICAL: Ungültige Methode Magento\Sales\Model\Order\Interceptor:: queueNewOrderEmail {"exception":"[object] (Magento\\Framework\\Exception\\LocalizedException(code: 0): Ungültige Methode Magento\\Sales\\Model\\Order\\Interceptor:: queueNewOrderEmail at /var/www/[REDACTED]/magento2/vendor/magento/framework/DataObject.php:399)"} []
```

`Model\Webhook\Event.php` uses the method `queueNewOrderEmail` which is no available anymore and emails should be sent using `Magento\Sales\Model\Order\Email\Sender\InvoiceSender`. This PR will remove usage of `queueNewOrderEmail` and use `InvoiceSender` instead to send the email.
