### PR TITLE
Replace Order/Payment->registerPaymentReviewAction not existing metho ...

### DIFF
--- a/Model/Webhook/Event.php
+++ b/Model/Webhook/Event.php
@@ -225,8 +225,8 @@ class Event
         $this->_order->getPayment()
             ->setPreparedMessage($webhookEvent->getSummary())
             ->setTransactionId($paymentResource->id)
-            ->setIsTransactionClosed(0)
-            ->registerPaymentReviewAction(\Magento\Sales\Model\Order\Payment::REVIEW_ACTION_UPDATE, false);
+	    ->setIsTransactionClosed(0)
+	    ->update(false);
         $this->_order->save();
     }
 


### PR DESCRIPTION
Replace function missing from \Magento\Sales\Model\Order\Payment::registerPaymentReviewAction since Magento 2 version 0.74.0-beta1 with \Magento\Sales\Model\Order\Payment::update in Model\Webhook\Event::paymentSaleCompleted

registerPaymentReviewAction in Magento:
https://github.com/magento/magento2/blob/0.74.0-beta1/app/code/Magento/Sales/Model/Order/Payment.php#L940

New update function:
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Sales/Model/Order/Payment.php#L1002