### PR TITLE
Fix rounding errors

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -865,6 +865,7 @@ class Api
                     -(
                         $quote->getBillingAddress()->getDiscountAmount()
                         + $quote->getBillingAddress()->getBaseDiscountTaxCompensationAmount()
+                        + $quote->getBillingAddress()->getShippingDiscountTaxCompensationAmount()
                     )
                 );
             }
@@ -874,6 +875,7 @@ class Api
                     -(
                         $quote->getShippingAddress()->getDiscountAmount()
                         + $quote->getShippingAddress()->getBaseDiscountTaxCompensationAmount()
+                        + $quote->getShippingAddress()->getShippingDiscountTaxCompensationAmount()
                     )
                 );
             }


### PR DESCRIPTION
Fixes related round error on totals, found in `var/log/PayPal.log`.
Tested on:
Magento 2.4.2
Tax configuration:
- Catalog Prices = Including tax
- Shipping Prices = Including tax
- Apply Customer Tax = After Discount
- Apply Discount On Prices = Including Tax
- Display Product Prices In Catalog = Including Tax
- Display Shipping Prices = Including Tax

In both sections groups: "Shopping Cart Display Settings" and "Orders, Invoices, Credit Memos Display Settings":
- Display Prices = Including Tax
- Display Subtotal = Including Tax
- Display Shipping Amount = Including Tax
- Include Tax In Order Total = No (Did not tested with Include Tax In Order Total = Yes)
- Display Zero Tax Subtotal = Yes