### PR TITLE
Make patch Payment a requirement for a successful checkout

### DIFF
--- a/Model/PaymentInformationManagement.php
+++ b/Model/PaymentInformationManagement.php
@@ -54,7 +54,11 @@ class PaymentInformationManagement
     public function patchPayment($cartId)
     {
         $quote = $this->quoteManagement->getActive($cartId);
-        return $this->payPalPlusApiFactory->create()->patchPayment($quote);
+        $result = $this->payPalPlusApiFactory->create()->patchPayment($quote);
+        if ($result === false) {
+            throw new \Exception('Could not patch payment for quote');
+        }
+        return $result;
     }
 
     public function handleComment($paymentMethod)


### PR DESCRIPTION
In certain cases a patch payment is not made or not successful. In this case the redirect to paypal should not happen. The toal sum could change (diffrent shipping mehtod, applied cart rules, etc..). If the exception is raised the checkout will not go through.